### PR TITLE
Centralize configuration

### DIFF
--- a/agent/workflow.py
+++ b/agent/workflow.py
@@ -9,7 +9,7 @@ from tools.business_tools import (
     get_order_details,
 )
 from db.db_setup import get_session
-from config import DATABASE_URL
+from config import DATABASE_URL, LOG_FILE
 from sqlalchemy import create_engine, text
 import datetime
 
@@ -75,8 +75,10 @@ def log_interaction(user_query: str, agent_answer: str):
     """
     Logs Q&A for learning, retraining, or analytics.
     """
-    with open("agent_interactions.log", "a", encoding="utf-8") as f:
-        f.write(f"{datetime.datetime.now().isoformat()} | Q: {user_query} | A: {agent_answer}\n")
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(
+            f"{datetime.datetime.now().isoformat()} | Q: {user_query} | A: {agent_answer}\n"
+        )
 
 def learning_node(state: AgentState) -> AgentState:
     """

--- a/config.py
+++ b/config.py
@@ -21,6 +21,11 @@ DATABASE_URL = f"sqlite:///{DATABASE_FILE}"
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 HF_TOKEN = os.getenv("HF_TOKEN")
 
+# === LLM Settings ===
+OPENAI_MODEL_NAME = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
+OPENAI_TEMPERATURE = float(os.getenv("OPENAI_TEMPERATURE", "0.2"))
+OPENAI_MAX_TOKENS = int(os.getenv("OPENAI_MAX_TOKENS", "512"))
+
 # === Model & Embedding Settings ===
 EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL_NAME", "sentence-transformers/all-MiniLM-L6-v2")
 COLLECTION_NAME = os.getenv("COLLECTION_NAME", "faq")

--- a/llm/llm.py
+++ b/llm/llm.py
@@ -1,7 +1,17 @@
-from config import OPENAI_API_KEY
+from config import (
+    OPENAI_API_KEY,
+    OPENAI_MODEL_NAME,
+    OPENAI_TEMPERATURE,
+    OPENAI_MAX_TOKENS,
+)
 from openai import OpenAI
 
-def openai_chat_completion(messages, model="gpt-4o-mini", temperature=0.2, max_tokens=512):
+def openai_chat_completion(
+    messages,
+    model: str = OPENAI_MODEL_NAME,
+    temperature: float = OPENAI_TEMPERATURE,
+    max_tokens: int = OPENAI_MAX_TOKENS,
+):
     """
     Calls OpenAI ChatCompletion API and returns the output text.
     messages: List of dicts with 'role' and 'content'.


### PR DESCRIPTION
## Summary
- centralize all configuration values in `config.py`
- use `LOG_FILE` in workflow logger
- configure default OpenAI LLM settings in config and import in llm module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a0c3db1a0832291b8043424c68b2d