### PR TITLE
Add Gradio chat UI

### DIFF
--- a/deploy/conda/env.yml
+++ b/deploy/conda/env.yml
@@ -19,3 +19,4 @@ dependencies:
       - python-dotenv>=1.0.1
       - typing-extensions>=4.11.0
       - sentence-transformers>=0.6.0
+      - gradio>=4.24.0

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,0 +1,20 @@
+import gradio as gr
+from agent.workflow import ask_agent
+from main import db_has_orders, vectorstore_exists, initial_setup
+
+
+def ensure_setup():
+    if not (db_has_orders() and vectorstore_exists()):
+        initial_setup()
+
+
+ensure_setup()
+
+demo = gr.ChatInterface(
+    fn=ask_agent,
+    title="Ecommerce AI Agent",
+    description="Ask questions about orders or general FAQs",
+)
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Summary
- add minimal Gradio chat interface
- include gradio in the Conda environment

## Testing
- `python -m py_compile gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687a8a790344832297c4f01f2190ebf1