### PR TITLE
Fix Gradio binding in Docker container

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -26,4 +26,6 @@ demo = gr.ChatInterface(
 )
 
 if __name__ == "__main__":
-    demo.launch()
+    # Bind to 0.0.0.0 so the Gradio server is reachable from outside the
+    # container when running under Docker or Docker Compose.
+    demo.launch(server_name="0.0.0.0", server_port=7860)


### PR DESCRIPTION
## Summary
- run `demo.launch()` with `server_name='0.0.0.0'` so the Gradio app is reachable when started via Docker Compose

## Testing
- `python -m py_compile gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_687b543d69088322b6021128fd2a18cd