### PR TITLE
Implement pydantic memory state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN pip install --no-cache-dir \
     openai>=1.25.0 \
     python-dotenv>=1.0.1 \
     typing-extensions>=4.11.0 \
+    pydantic>=2.7.1 \
     sentence-transformers>=0.6.0 \
     gradio>=4.24.0
 

--- a/agent/workflow.py
+++ b/agent/workflow.py
@@ -1,6 +1,7 @@
 """Workflow definition for the conversational agent."""
 
 from langgraph.graph import StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
 from agent.state import AgentState
 from llm.llm import classify_intent, rephrase_text
 from tools.business_tools import (
@@ -31,21 +32,19 @@ def initialize_engine(database_url: str = DATABASE_URL):
     return engine
 
 def perception_node(state: AgentState) -> AgentState:
-    """
-    Intent classification node: uses LLM to determine query intent.
-    """
-    query = state["input"]
+    """Intent classification node."""
+
+    query = state.input
     # Use the LLM to determine what the user wants to do
     intent = classify_intent(query)
-    state["classification"] = intent
+    state.classification = intent
     return state
 
 def tool_node(state: AgentState) -> AgentState:
-    """
-    Dispatch to the correct tool based on classified intent.
-    """
-    classification = state["classification"]
-    query = state["input"]
+    """Dispatch to the correct tool based on classified intent."""
+
+    classification = state.classification
+    query = state.input
     # Lazily create DB engine and session for each invocation
     engine_local = initialize_engine()
     session = get_session(engine_local)
@@ -69,7 +68,7 @@ def tool_node(state: AgentState) -> AgentState:
     finally:
         # Always close the DB session
         session.close()
-    state["tool_output"] = output
+    state.tool_output = output
     return state
 
 def answer_node(state: AgentState) -> AgentState:
@@ -77,12 +76,12 @@ def answer_node(state: AgentState) -> AgentState:
     Formats the output for final agent answer.
     """
     # Take the raw tool output and rephrase it for a nicer user experience
-    answer = state["tool_output"]
+    answer = state.tool_output or ""
     rephrased = rephrase_text(answer)
-    state["output"] = rephrased
+    state.output = rephrased
     return state
 
-def log_interaction(user_query: str, agent_answer: str):
+def log_interaction(user_query: str, agent_answer: str) -> None:
     """
     Logs Q&A for learning, retraining, or analytics.
     """
@@ -93,17 +92,15 @@ def log_interaction(user_query: str, agent_answer: str):
         )
 
 def learning_node(state: AgentState) -> AgentState:
-    """
-    Learning step: log output for future improvement.
-    """
-    log_interaction(state.get("input", ""), state.get("output", ""))
+    """Learning step: log output for future improvement."""
+
+    log_interaction(state.input, state.output or "")
     return state
 
 def build_workflow() -> StateGraph:
-    """
-    Compiles the LangGraph workflow using AgentState.
-    Returns the compiled StateGraph.
-    """
+    """Compile the LangGraph workflow with in-memory checkpointing."""
+
+    checkpointer = InMemorySaver()
     workflow = StateGraph(AgentState)
     workflow.add_node("perception", perception_node)
     workflow.add_node("tool_use", tool_node)
@@ -113,21 +110,33 @@ def build_workflow() -> StateGraph:
     workflow.add_edge("perception", "tool_use")
     workflow.add_edge("tool_use", "answer")
     workflow.add_edge("answer", "learning")
-    return workflow.compile()
+    return workflow.compile(checkpointer=checkpointer)
 
 # --- Main agent callable ---
 
 graph = build_workflow()
 
+_conversation_state: AgentState | None = None
+
+
 def ask_agent(user_query: str) -> str:
-    """
-    Single entrypoint for conversational agent.
-    Returns agent's answer for a user query.
-    """
-    state = {"input": user_query}
-    # Execute the workflow graph and return the final answer
-    result = graph.invoke(state)
-    return result["output"]
+    """Single entrypoint for the conversational agent with short-term memory."""
+
+    global _conversation_state
+    if _conversation_state is None:
+        _conversation_state = AgentState(input=user_query)
+    else:
+        _conversation_state.input = user_query
+        _conversation_state.classification = None
+        _conversation_state.tool_output = None
+        _conversation_state.output = None
+
+    # Execute the workflow and update state
+    _conversation_state = graph.invoke(_conversation_state)
+    assert _conversation_state is not None
+    # Append to short-term history (keep last 3 turns)
+    _conversation_state.add_turn(user_query, _conversation_state.output or "")
+    return _conversation_state.output or ""
 
 # Example usage for CLI
 if __name__ == "__main__":

--- a/deploy/conda/env.yml
+++ b/deploy/conda/env.yml
@@ -18,5 +18,6 @@ dependencies:
       - openai>=1.25.0
       - python-dotenv>=1.0.1
       - typing-extensions>=4.11.0
+      - pydantic>=2.7.1
       - sentence-transformers>=0.6.0
       - gradio>=4.24.0

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -15,7 +15,7 @@ def ensure_setup():
 ensure_setup()
 
 def gradio_ask(message: str, history: list[tuple[str, str]]) -> str:
-    """Wrapper for gradio ChatInterface."""
+    """Return the agent response, ignoring history (managed internally)."""
     return ask_agent(message)
 
 # Instantiate the basic chat interface

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ def db_has_orders() -> bool:
 def cli_loop():
     """
     Simple command-line chat loop for testing the agent.
+    Conversation state is kept in memory between turns.
     """
     print("\nEcommerce AI Agent (type 'quit' or 'exit' to stop).")
     while True:


### PR DESCRIPTION
## Summary
- rework `AgentState` using Pydantic and add short‑term memory helper
- update workflow to use the new model
- keep an in-memory `AgentState` between calls and limit history to 3 turns
- compile workflow with `InMemorySaver`
- include Pydantic in Dockerfile and conda env
- clarify memory usage in CLI and Gradio app

## Testing
- `pyright agent` *(fails: Import "pydantic" could not be resolved)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883559c2e0c8322892e2d2b5a594fa6