### PR TITLE
Use history when rephrasing answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ AI: [semantic FAQ answer]
 You: Check order status for ID 000229ec398224ef6ca0657da4fc703e
 AI: Order 000229ec398224ef6ca0657da4fc703e status: delivered
 ```
+The agent now uses the last few conversation turns when rephrasing answers,
+so follow-up questions sound more natural.
 
 ### 5. Launch the Web Chat (Gradio)
 

--- a/agent/workflow.py
+++ b/agent/workflow.py
@@ -2,7 +2,7 @@
 
 from langgraph.graph import StateGraph
 from langgraph.checkpoint.memory import InMemorySaver
-from agent.state import AgentState
+from agent.state import AgentState, AgentTurn
 from llm.llm import classify_intent, rephrase_text
 from tools.business_tools import (
     search_faq,
@@ -117,9 +117,10 @@ def answer_node(state: AgentState) -> AgentState:
     AgentState
         Updated state with ``output`` filled.
     """
-    # Take the raw tool output and rephrase it for a nicer user experience
+    # Take the raw tool output and rephrase it using conversation history
     answer = state.tool_output or ""
-    rephrased = rephrase_text(answer)
+    history_with_current = state.history + [AgentTurn(user=state.input, agent=answer)]
+    rephrased = rephrase_text(answer, history=history_with_current)
     state.output = rephrased
     return state
 


### PR DESCRIPTION
## Summary
- incorporate `AgentTurn` list into `rephrase_text`
- use conversation history in `answer_node`
- document the new behavior

## Testing
- `python -m py_compile agent/workflow.py llm/llm.py`

------
https://chatgpt.com/codex/tasks/task_e_6883a4d56f588322b996ca58651955a4